### PR TITLE
Do not respect application overrides when saving the base class.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -49,8 +49,8 @@ python_requires = >=3.8
 # For more information, check out https://semver.org/.
 install_requires =
     importlib-metadata; python_version<"3.8"
-    dolomite-base>=0.2.4
-    dolomite-matrix>=0.2.1
+    dolomite-base>=0.3.0
+    dolomite-matrix>=0.3.0
     dolomite-ranges>=0.1.3
     summarizedexperiment>=0.4.4
 

--- a/src/dolomite_se/read_ranged_summarized_experiment.py
+++ b/src/dolomite_se/read_ranged_summarized_experiment.py
@@ -3,6 +3,7 @@ import os
 import dolomite_base as dl
 from dolomite_base.read_object import read_object_registry
 from summarizedexperiment import RangedSummarizedExperiment
+from .read_summarized_experiment import read_summarized_experiment
 
 read_object_registry["ranged_summarized_experiment"] = (
     "dolomite_se.read_ranged_summarized_experiment"
@@ -34,8 +35,13 @@ def read_ranged_summarized_experiment(
         :py:class:`~summarizedexperiment.RangedSummarizedExperiment.RangedSummarizedExperiment`
         with file-backed arrays in the assays.
     """
-    metadata["type"] = "summarized_experiment"
-    se = dl.alt_read_object(path, metadata=metadata, **kwargs)
+
+    # We don't try to respect application overrides when loading the base
+    # instance. Application developers should just pretend that we copied the
+    # code from read_summarized_experiment, rather than trying to inject in
+    # custom code at this point, which gets too complicated - see the
+    # associated commentary for save_ranged_summarized_experiment.
+    se = read_summarized_experiment(path, metadata=metadata, **kwargs)
 
     rse = RangedSummarizedExperiment(
         assays=se.get_assays(),


### PR DESCRIPTION
This is more predictable and avoids multiple calls to overriding methods when traversing the class hierarchy via saveObject/readObject. It aligns with ArtifactDB/alabaster.se@caa061670811fa8cfbd710f0655de94a9f489699.